### PR TITLE
"without models" option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@
 
 # Vim
 *.swp
+
+# Debian Build
+build
+src/js_test/node_modules/

--- a/README.md
+++ b/README.md
@@ -236,62 +236,27 @@ updateSocket.on('message', function(wakeword_buffer) {
 
 ## Build Debian package from source (optional)
 
-Update source and submodules:
+Update source and submodules and install headers:
 
 ``` bash
 cd matrix-malos-wakeword
 git submodule update --init --recursive
-
+sudo apt-get install libmatrixio-protos-dev
 ```
 
-For preparation for build debian package first extract sources with [git-archive-all.sh](https://github.com/meitar/git-archive-all.sh/wiki) like this:
+Build Debian package on RaspberryPi:
 
 ``` bash
-sudo apt-get install devscripts dh-make --no-install-recommends
-mkdir ../work
-git-archive-all.sh
-mv malos-wakeword.tar ../work/
-cd .. && mkdir matrix-creator-malos-wakeword-0.1.2 && cd matrix-creator-malos-wakeword-0.1.2
-tar xf ../malos-wakeword.tar
-cd .. && tar Jcf matrix-creator-malos-wakeword_0.1.2.orig.tar.xz matrix-creator-malos-wakeword-0.1.2
+debuild -us -uc -j4
 ```
-**Note**: please check or change version number and check `xz` extension
 
-Run `dh_make` with `m` option:
+Install and start wakeword service:
 
 ``` bash
-cd matrix-creator-malos-wakeword-0.1.2
-dh_make
+cd ..
+sudo dpkg -i ../matrix-creator-malos-wakeword_xxx_armhf.deb
+sudo service matrix-creator-malos-wakeword start
 ```
 
-Output like this:
-
-``` bash
-pi:matrix-creator-malos-wakeword-0.1.2$ dh_make
-
-Type of package: single binary, indep binary, multiple binary, library, kernel module, kernel patch?
- [s/i/m/l/k/n] m
-
-Maintainer name  : unknown
-Email-Address    : pi@unknown 
-Date             : Mon, 22 May 2017 18:25:49 -0500
-Package Name     : matrix-creator-malos-wakeword
-Version          : 0.1.2
-License          : blank
-Type of Package  : Multi-Binary
-Hit <enter> to confirm: 
-Skipping creating ../matrix-creator-malos-wakeword_0.1.2.orig.tar.xz because it already exists
-You already have a debian/ subdirectory in the source tree.
-dh_make will not try to overwrite anything.
-```
-You already have a debian/ subdirectory in the source tree.
-dh_make will not try to overwrite anything.
-```
-
-Build Debian package:
-
-``` bash
-debuild -us -uc
-```
 
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ sudo npm installt
 node test_wakeword.js
 ```
 
-[explanation](https://github.com/matrix-io/matrix-malos-wakeword/tree/av/blob/master/README.md#javascript-example)
+[explanation](#javascript-example)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -16,15 +16,18 @@ Wakeword voice service for MALOS. The last version support:
 
 ### Raspbian Dependencies 
 
-Before, please install MALOS on your RaspberryPi3 and perform device reboot. For more details: [Getting Started Guide](https://github.com/matrix-io/matrix-creator-quickstart/wiki/2.-Getting-Started)
+Before, please install FPGA and MCU drivers on your RaspberryPi3 and perform device reboot. 
 
 ``` 
 echo "deb http://packages.matrix.one/matrix-creator/ ./" | sudo tee --append /etc/apt/sources.list
+sudo apt-get clean
 sudo apt-get update
 sudo apt-get upgrade
-sudo apt-get install matrix-creator-init matrix-creator-malos cmake g++ git libzmq3-dev --no-install-recommends
+sudo apt-get install matrix-creator-init cmake g++ git libzmq3-dev --no-install-recommends
 reboot
 ```
+** NOTE: ** Please check that sensors and everloop work well. For more details: [Getting Started Guide](https://matrix-io.github.io/matrix-documentation/MALOS/overview/)
+
 
 Install matrix-creator-malos-wakeword package and dependencies:
 
@@ -52,7 +55,6 @@ cd /home/pi
 git clone --recursive https://github.com/matrix-io/matrix-malos-wakeword.git
 cp -r matrix-malos-wakeword/assets .
 ```
-
 
 Run nodejs example and say some voice commands: `mia ring red`, `mia ring
 orange`, `mia ring clear` for example:
@@ -127,16 +129,38 @@ var creator_ip = '127.0.0.1'
 var creator_wakeword_base_port = 60001;
 ```
 
+#### Load Proto files
+
+``` javascript
+var driverProtoBuilder = protoBuf.loadProtoFile({
+  root: PROTO_PATH, 
+  file: 'matrix_io/malos/v1/driver.proto'
+})
+var ioProtoBuilder = protoBuf.loadProtoFile({
+  root: PROTO_PATH, 
+  file: 'matrix_io/malos/v1/io.proto'
+})
+
+var matrix = {
+  malos: {
+    v1: {
+      driver: driverProtoBuilder.build("matrix_io.malos.v1.driver"),
+      io: ioProtoBuilder.build("matrix_io.malos.v1.io")
+    }
+  }
+}
+```
+
 #### Config and start wakeupword service
 
 ``` javascript
 function startWakeUpRecognition(){
   console.log('<== config wakeword recognition..')
-  var wakeword_config = new matrixMalosBuilder.WakeWordParams;
+  var wakeword_config = new matrix.malos.v1.io.WakeWordParams;
   wakeword_config.set_wake_word("MIA");
   wakeword_config.set_lm_path("/home/pi/assets/9854.lm");
   wakeword_config.set_dic_path("/home/pi/assets/9854.dic");
-  wakeword_config.set_channel(matrixMalosBuilder.WakeWordParams.MicChannel.channel0);
+  wakeword_config.set_channel(matrix.malos.v1.io.WakeWordParams.MicChannel.channel8);
   wakeword_config.set_enable_verbose(false)
   sendConfigProto(wakeword_config);
 }
@@ -147,20 +171,21 @@ function startWakeUpRecognition(){
 ``` javascript
 function stopWakeUpRecognition(){
   console.log('<== stop wakeword recognition..')
-  var wakeword_config = new matrixMalosBuilder.WakeWordParams;
+  var wakeword_config = new matrix.malos.v1.io.WakeWordParams;
   wakeword_config.set_stop_recognition(true)
   sendConfigProto(wakeword_config);
 }
 ```
 
 #### Register wakeupword callbacks (voice commands)
+
 ``` javascript
 var updateSocket = zmq.socket('sub')
 updateSocket.connect('tcp://' + creator_ip + ':' + (creator_wakeword_base_port + 3))
 updateSocket.subscribe('')
 
 updateSocket.on('message', function(wakeword_buffer) {
-  var wakeWordData = new matrixMalosBuilder.WakeWordParams.decode(wakeword_buffer);
+  var wakeWordData = new matrix.malos.v1.io.WakeWordParams.decode(wakeword_buffer);
   console.log('==> WakeWord Reached:',wakeWordData.wake_word)
     
     switch(wakeWordData.wake_word) {
@@ -179,11 +204,8 @@ updateSocket.on('message', function(wakeword_buffer) {
       case "MIA RING CLEAR":
         setEverloop(0, 0, 0, 0, 0) 
         break;
-      default:
-        text = "==> Not handled voice command";
     }
 });
-
 ```
 
 ## Custom language and phrases for recognition 
@@ -257,6 +279,9 @@ License          : blank
 Type of Package  : Multi-Binary
 Hit <enter> to confirm: 
 Skipping creating ../matrix-creator-malos-wakeword_0.1.2.orig.tar.xz because it already exists
+You already have a debian/ subdirectory in the source tree.
+dh_make will not try to overwrite anything.
+```
 You already have a debian/ subdirectory in the source tree.
 dh_make will not try to overwrite anything.
 ```

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ echo "deb http://packages.matrix.one/matrix-creator/ ./" | sudo tee --append /et
 sudo apt-get clean
 sudo apt-get update
 sudo apt-get upgrade
-sudo apt-get install matrix-creator-init cmake g++ git libzmq3-dev --no-install-recommends
+sudo apt-get install matrix-creator-init wiringpi cmake g++ git libzmq3-dev --no-install-recommends
 reboot
 ```
-** NOTE: ** Please check that sensors and everloop work well. For more details: [Getting Started Guide](https://matrix-io.github.io/matrix-documentation/MALOS/overview/)
+**NOTE**: Please check that sensors and everloop work well. For more details: [Getting Started Guide](https://matrix-io.github.io/matrix-documentation/MALOS/overview/)
 
 
 Install matrix-creator-malos-wakeword package and dependencies:
@@ -66,6 +66,8 @@ cd src/js_test
 sudo npm installt
 node test_wakeword.js
 ```
+
+[explanation](https://github.com/matrix-io/matrix-malos-wakeword/tree/av/blob/master/README.md#javascript-example)
 
 ## Documentation
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -2,5 +2,4 @@
 
 echo "Enabling MALOS wakeword service"
 systemctl enable matrix-creator-malos-wakeword
-
 echo "Please restart your Raspberry Pi after installation"

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+echo "Removing MALOS wakeword service"
+
+systemctl stop [servicename]
+systemctl disable [servicename]
+rm /etc/systemd/system/[servicename]
+rm /etc/systemd/system/[servicename] symlinks that might be related
+systemctl daemon-reload
+systemctl reset-failed
+
+

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,11 +1,8 @@
 #!/bin/bash -e
 
 echo "Removing MALOS wakeword service"
-
-systemctl stop [servicename]
-systemctl disable [servicename]
-rm /etc/systemd/system/[servicename]
-rm /etc/systemd/system/[servicename] symlinks that might be related
+systemctl stop matrix-creator-malos-wakeword
+systemctl disable matrix-creator-malos-wakeword
 systemctl daemon-reload
 systemctl reset-failed
 

--- a/matrix-creator-malos-wakeword.service
+++ b/matrix-creator-malos-wakeword.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Wakeword service for Matrix Abstraction Layer for OS
+After=matrix-creator-malos.service
 
 [Service]
 Type=simple
@@ -7,4 +8,3 @@ ExecStart=/usr/bin/malos_wakeword
 
 [Install]
 WantedBy=multi-user.target
-After=matrix-creator-malos.service

--- a/src/driver_wakeword.cpp
+++ b/src/driver_wakeword.cpp
@@ -67,11 +67,11 @@ bool WakeWordDriver::startPipe(bool withWakeword) {
   std::string cmd;
   if (withWakeword) {
     cmd = std::string(
-        "./malos_psphinx -keyphrase \"" + wakeword +
+        "malos_psphinx -keyphrase \"" + wakeword +
         "\" -kws_threshold 1e-20 -dict \"" + dic_path + "\" -lm \"" + lm_path +
         "\" -inmic yes -adcdev mic_channel" + std::to_string(channel));
   } else {
-    cmd = std::string("./malos_psphinx -inmic yes -adcdev mic_channel" +
+    cmd = std::string("malos_psphinx -inmic yes -adcdev mic_channel" +
                       std::to_string(channel));
   }
   if (!verbose)

--- a/src/driver_wakeword.cpp
+++ b/src/driver_wakeword.cpp
@@ -47,14 +47,9 @@ bool WakeWordDriver::ProcessConfig(const pb::driver::DriverConfig &config) {
     return true;
   }
   loadParameters(wakeword_params);
-  if (validatePaths()) {
-    verbose = wakeword_params.enable_verbose();
-    enabled = startPipe();
-    return enabled;
-  } else {
-    zmq_push_error_->Send("invalid configuration paths");
-    return false;
-  }
+  verbose = wakeword_params.enable_verbose();
+  return startPipe(validatePaths());
+    //zmq_push_error_->Send("invalid configuration paths");
 }
 
 void WakeWordDriver::loadParameters(
@@ -68,15 +63,20 @@ void WakeWordDriver::loadParameters(
   std::cerr << "==> dictionary path: " << dic_path << std::endl;
 }
 
-bool WakeWordDriver::startPipe() {
-  std::string cmd = std::string(
-      "malos_psphinx -keyphrase \"" + wakeword +
-      "\" -kws_threshold 1e-20 -dict \"" + dic_path + "\" -lm \"" + lm_path +
-      "\" -inmic yes -adcdev mic_channel" + std::to_string(channel));
+bool WakeWordDriver::startPipe(bool withWakeword) {
+  std::string cmd;
+  if (withWakeword) {
+    cmd = std::string(
+        "./malos_psphinx -keyphrase \"" + wakeword +
+        "\" -kws_threshold 1e-20 -dict \"" + dic_path + "\" -lm \"" + lm_path +
+        "\" -inmic yes -adcdev mic_channel" + std::to_string(channel));
+  } else {
+    cmd = std::string("./malos_psphinx -inmic yes -adcdev mic_channel" +
+                      std::to_string(channel));
+  }
+  if (!verbose)
+    cmd = cmd + " 2> /dev/null";
 
-  if (!verbose) cmd = cmd + " 2> /dev/null";
-
-  std::cout << "Starting PocketSphinx thread.." << std::endl;
   if (!(sphinx_pipe_ = popen(cmd.c_str(), "r"))) {
     return false;
   }
@@ -84,8 +84,9 @@ bool WakeWordDriver::startPipe() {
   std::thread pocketsphinx_thread(&WakeWordDriver::PocketSphinxProcess, this);
   pocketsphinx_thread.detach();
   returnMatch("voice recognition ready");
+  enabled = true;
 
-  return true;
+  return enabled;
 }
 
 bool WakeWordDriver::stopPipe() {

--- a/src/driver_wakeword.h
+++ b/src/driver_wakeword.h
@@ -49,8 +49,9 @@ class WakeWordDriver : public MalosBase {
   // Reads config parameters from proto
   void loadParameters(const pb::io::WakeWordParams &wakeword_params);
 
-  // Starts malos_psphinx thread
-  bool startPipe();
+  // Starts malos_psphinx thread 
+  // withWakeword parameter is true if there paths
+  bool startPipe(bool withWakeword);
 
   // Kills malos_psphinx thread
   bool stopPipe();

--- a/src/js_test/test_continous_recognition.js
+++ b/src/js_test/test_continous_recognition.js
@@ -1,0 +1,139 @@
+
+// This is how we connect to the creator. IP and port.
+// The IP is the IP I'm using and you need to edit it.
+// By default, MALOS has its 0MQ ports open to the world.
+
+// Every device is identified by a base port. Then the mapping works
+// as follows:
+// BasePort     => Configuration port. Used to config the device.
+// BasePort + 1 => Keepalive port. Send pings to this port.
+// BasePort + 2 => Error port. Receive errros from device.
+// BasePort + 3 => Data port. Receive data from device.
+
+var creator_ip = '127.0.0.1';
+var creator_wakeword_base_port = 60001;
+var creator_everloop_base_port = 20013 + 8 // port for Everloop driver.
+var protoBuf = require("protobufjs");
+var zmq = require('zmq');
+
+const PROTO_PATH = '../../protocol-buffers/'
+
+//  Load proto files
+var driverProtoBuilder = protoBuf.loadProtoFile({
+  root: PROTO_PATH, 
+  file: 'matrix_io/malos/v1/driver.proto'
+})
+var ioProtoBuilder = protoBuf.loadProtoFile({
+  root: PROTO_PATH, 
+  file: 'matrix_io/malos/v1/io.proto'
+})
+
+var matrix = {
+  malos: {
+    v1: {
+      driver: driverProtoBuilder.build("matrix_io.malos.v1.driver"),
+      io: ioProtoBuilder.build("matrix_io.malos.v1.io")
+    }
+  }
+}
+
+var configSocket = zmq.socket('push')
+configSocket.connect('tcp://' + creator_ip + ':' + creator_wakeword_base_port /* config */)
+
+// ********** Start error management.
+var errorSocket = zmq.socket('sub')
+errorSocket.connect('tcp://' + creator_ip + ':' + (creator_wakeword_base_port + 2))
+errorSocket.subscribe('')
+errorSocket.on('message', function(error_message) {
+  process.stdout.write('Received Wakeword error: ' + error_message.toString('utf8') + "\n")
+});
+// ********** End error management.
+
+/**************************************
+ * start/stop service functions
+ **************************************/
+
+function startWakeUpRecognition(){
+  console.log('<== config wakeword recognition..')
+  var wakeword_config = new matrix.malos.v1.io.WakeWordParams;
+  wakeword_config.set_channel(matrix.malos.v1.io.WakeWordParams.MicChannel.channel8);
+  wakeword_config.set_enable_verbose(false)
+  sendConfigProto(wakeword_config);
+}
+
+function stopWakeUpRecognition(){
+  console.log('<== stop wakeword recognition..')
+  var wakeword_config = new matrix.malos.v1.io.WakeWordParams;
+  wakeword_config.set_stop_recognition(true)
+  sendConfigProto(wakeword_config);
+}
+
+/**************************************
+ * Register wakeword callbacks
+ **************************************/
+
+var updateSocket = zmq.socket('sub')
+updateSocket.connect('tcp://' + creator_ip + ':' + (creator_wakeword_base_port + 3))
+updateSocket.subscribe('')
+
+updateSocket.on('message', function(wakeword_buffer) {
+  var wakeWordData = new matrix.malos.v1.io.WakeWordParams.decode(wakeword_buffer);
+  console.log('==> WakeWord Reached:',wakeWordData.wake_word)
+    
+    switch(wakeWordData.wake_word) {
+      case "MIA RING RED":
+        setEverloop(255, 0, 25, 0, 0.05)
+        break;
+      case "MIA RING BLUE":
+        setEverloop(0, 25, 255, 0, 0.05) 
+        break;
+      case "MIA RING GREEN":
+        setEverloop(0, 255, 100, 0, 0.05) 
+        break;
+      case "MIA RING ORANGE":
+        setEverloop(255, 77, 0, 0, 0.05) 
+        break;
+      case "MIA RING CLEAR":
+        setEverloop(0, 0, 0, 0, 0) 
+        break;
+    }
+});
+
+/**************************************
+ * Everloop Ring LEDs handler
+ **************************************/
+
+var ledsConfigSocket = zmq.socket('push')
+ledsConfigSocket.connect('tcp://' + creator_ip + ':' + creator_everloop_base_port /* config */)
+
+function setEverloop(r, g, b, w, i) {
+    var config = new matrix.malos.v1.driver.DriverConfig
+    config.image = new matrix.malos.v1.io.EverloopImage
+    for (var j = 0; j < 35; ++j) {
+      var ledValue = new matrix.malos.v1.io.LedValue;
+      ledValue.setRed(Math.round(r*i));
+      ledValue.setGreen(Math.round(g*i));
+      ledValue.setBlue(Math.round(b*i));
+      ledValue.setWhite(Math.round(w*i));
+      config.image.led.push(ledValue)
+    }
+    ledsConfigSocket.send(config.encode().toBuffer());
+}
+
+/**************************************
+ * sendConfigProto: build Proto message 
+ **************************************/
+
+function sendConfigProto(cfg){
+  var config = new matrix.malos.v1.driver.DriverConfig
+  config.set_wakeword(cfg)
+  configSocket.send(config.encode().toBuffer())
+}
+
+/**********************************************
+ ****************** MAIN **********************
+ **********************************************/
+
+startWakeUpRecognition();
+
+


### PR DESCRIPTION
In this branch, wakeword and model paths are optional. All English dictionary is loaded, in consequence the memory use is increased 1500% (from 8M to 120M of RAM) and CPU use is increased 2475% (from ~4% of CPU to 99% of CPU in standby)

Because of this, the dictionary must be reduced to a few pull of sentences as in the first version of wakeword or next planned version, with custom models but same reduced dictionary.

To run this branch, I wrote a new example: `test_continous_recognition.js`